### PR TITLE
Add support for Firefox Nightly 18

### DIFF
--- a/src/public/gissues.js
+++ b/src/public/gissues.js
@@ -430,6 +430,9 @@ function onFilterApproved(event) {
 }
 
 $(function() {
+	$.ajaxSetup({
+		dataType: "json"
+	});
 	parseOptions();
 	$('.gfilter').change(onFilterChanged).keypress(onFilterApproved);
 	loadRepositories();


### PR DESCRIPTION
Firefox Nightly 18 seems to cause jQuery to detect the return format of the sent Ajax requests to string instead of JSON. This causes the repo list to load incorrectly.
